### PR TITLE
add struct mgcap as a global variable instead of the struct mgc_dev.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,12 @@
 # Debug files
 *.dSYM/
 *.su
+
+
+# Kmod compile output files
+*.mod.c
+.*.cmd
+.tmp_versions*
+modules.order
+Module.symvers
+*.out

--- a/kmod/mgcap_rx.c
+++ b/kmod/mgcap_rx.c
@@ -8,12 +8,18 @@
 #include "mgcap.h"
 #include "mgcap_rx.h"
 
+static struct mgc_dev *mgc_dev_get_rcu(const struct net_device *d)
+{
+	return rcu_dereference (d->rx_handler_data);
+}
+
 /* note: already called with rcu_read_lock */
 rx_handler_result_t mgc_handle_frame(struct sk_buff **pskb)
 {
 //	struct mgc_dev *dev = rcu_dereference(skb->dev->rx_handler_data);
 	rx_handler_result_t res = RX_HANDLER_CONSUMED;
 	struct sk_buff *skb = *pskb;
+	struct mgc_dev *mgc = mgc_dev_get_rcu(skb->dev);
 	struct mgc_ring *rxbuf;
 	uint64_t tstamp;
 	uint16_t pktlen;


### PR DESCRIPTION
This introduces `struct mgcap` contains dev_list for multiple `struct mgc_dev`s instead of one `struct mgc_dev` for a mgcaped device.

To add a new mgcaped device, call `register_mgc_dev(char *ifname)`, and delete it by `unregister_mgc_dev(struct mgc_dev *mgc)`.
