### PR TITLE
add "capture mode" feature to handle drop or pass captured packets

### DIFF
--- a/kmod/mgcap.h
+++ b/kmod/mgcap.h
@@ -35,6 +35,8 @@ struct mgc_dev {
 
 	struct net_device *dev;
 
+	int capture_mode;	/* CAPTURE_MODE_DROP/PASS */
+
 	uint8_t num_cpus;
 
 	struct rxring *rxrings;

--- a/kmod/mgcap_netlink.h
+++ b/kmod/mgcap_netlink.h
@@ -14,11 +14,13 @@
  * mgcap netlink commands
  *   START (DEVICE): start mgcap for a specified device
  *   STOP (DEVICE):  stop mgcap for a specified evice
+ *   SET_CAPTURE_MODE (DEVICE, MODE): set capture mode, drop or pass
  */
 
 enum {
 	MGCAP_CMD_START,
 	MGCAP_CMD_STOP,
+	MGCAP_CMD_SET_CAPTURE_MODE,
 
 	__MGCAP_CMD_MAX,
 };
@@ -28,12 +30,16 @@ enum {
 /* ATTR types*/
 enum {
 	MGCAP_ATTR_UNSPEC,
-	MGCAP_ATTR_DEVICE,	/* 32bit ifindex */
+	MGCAP_ATTR_DEVICE,		/* 32bit ifindex */
+	MGCAP_ATTR_CAPTURE_MODE,	/* 32bit capture mode */
 
 	__MGCAP_ATTR_MAX,
 };
 #define MGCAP_ATTR_MAX	(__MGCAP_ATTR_MAX - 1)
 
-
+/* Capture mode */
+#define MGCAP_CAPTURE_MODE_DROP 1	/* captured packets are dropped */
+#define MGCAP_CAPTURE_MODE_PASS 2	/* captured packets are passed to
+                                         * normal kernel network stack */
 
 #endif /* _LINUX_MGCAP_NETLINK_H_ */


### PR DESCRIPTION
This patch set introduces capture mode to handle behavior of captured packets.
In the drop mode, packets received by a mgcaped device is dropped (original behavior). In contrast to the drop mode, pass mode passes received packets to normal kernel network stack by RX_HANDLER_PASS.

The capture mode can be changed via `ip mgcap set mode` command.

```
# insmod kmod/mgcap.ko
# cd src/iproute2-4.8.0/

# ./ip/ip mgcap help
usage:  ip mgcap { start | stop } [ dev DEVICE ]

        ip mgcap set { dev DEVICE } {
                 mode { drop | pass } }


# ./ip/ip mgcap start dev lo    (default mode is drop)
# ping -c 3 -W 1 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.

--- 127.0.0.1 ping statistics ---
3 packets transmitted, 0 received, 100% packet loss, time 1999ms

# ./ip/ip mgcap set dev lo mode pass    (set pass mode)
# ls /dev/mgcap/
lo
# ping -c 3 -W 1 127.0.0.1
PING 127.0.0.1 (127.0.0.1) 56(84) bytes of data.
64 bytes from 127.0.0.1: icmp_seq=1 ttl=64 time=0.017 ms
64 bytes from 127.0.0.1: icmp_seq=2 ttl=64 time=0.022 ms
64 bytes from 127.0.0.1: icmp_seq=3 ttl=64 time=0.027 ms

--- 127.0.0.1 ping statistics ---
3 packets transmitted, 3 received, 0% packet loss, time 1998ms
rtt min/avg/max/mdev = 0.017/0.022/0.027/0.004 ms
#
```

Then, you can `mgdump` character devices at the same time.
