### PR TITLE
Add libmgcap

### DIFF
--- a/src/libmgcap/Makefile
+++ b/src/libmgcap/Makefile
@@ -1,0 +1,17 @@
+TARGET = mgcap
+
+CFLAGS = -Wall -O2
+
+SRCS := mgcap.c
+OBJS = $(subst .c,.o,$(SRCS))
+
+${TARGET}: ${OBJS}
+	ar rcs lib${TARGET}.a $^
+
+.c.o:
+	$(CC) ${CFLAGS} -o $@ -c $<
+
+.PHONY: clean
+clean:
+	rm -f ${TARGET} ${OBJS}
+

--- a/src/libmgcap/mgcap.c
+++ b/src/libmgcap/mgcap.c
@@ -1,0 +1,105 @@
+#include "mgcap.h"
+
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+
+// #define MGC_SNAPLEN (10 + 96)
+#define MGC_SNAPLEN (128)
+#define MGCAP_ERR_LEN (256)
+
+struct mgcap_ {
+	int fd_;
+	char* dev_path_;
+	char* errmsg_;
+	uint8_t* cursol_;
+	uint8_t ibuf_[MGC_SNAPLEN * 1024];  // number of max input packets: 1024
+	int read_size_;
+};
+
+
+mgcap_t* new_mgcap() {
+	mgcap_t* mg = malloc(sizeof(mgcap_t));
+	mg->fd_ = -1;
+	mg->dev_path_ = NULL;
+	mg->errmsg_ = calloc(MGCAP_ERR_LEN, sizeof(char));
+	mg->cursol_ = NULL;
+	return mg;
+}
+
+void destroy_mgcap(mgcap_t* mg) {
+	assert(mg);
+
+	if (mg->dev_path_) {
+		free(mg->dev_path_);
+	}
+	
+	if (mg->fd_ >= 0) {
+		close(mg->fd_);
+	}
+
+	free(mg->errmsg_);
+	free(mg);
+}
+
+int mgcap_set_device(mgcap_t* mg, const char* dev_name) {
+	if (mg->dev_path_) {
+		free(mg->dev_path_);
+	}
+	if (mg->fd_ != 0) {
+		close(mg->fd_);
+	}
+
+	static const char* dev_prefix = "/dev/mgcap/";
+	const int p_len = strlen(dev_prefix) + strlen(dev_name) + 1;
+	mg->dev_path_ = calloc(p_len, sizeof(char));
+	snprintf(mg->dev_path_, p_len, "%s%s", dev_prefix, dev_name);
+
+	mg->fd_ = open(mg->dev_path_, O_RDONLY);
+	// printf("%d\n", mg->fd_);
+	if (mg->fd_ < 0) {
+		strerror_r(errno, mg->errmsg_, MGCAP_ERR_LEN);
+		return -1;
+	}
+
+	return 0;
+}
+
+
+int mgcap_next(mgcap_t* mg, void** pktptr, mgcap_hdr* hdr) {
+	if (mg->cursol_ == NULL) {
+		int rc;
+		while (0 >= (rc = read(mg->fd_, &(mg->ibuf_[0]), sizeof(mg->ibuf_)))) {
+			usleep(100);
+		}
+
+		mg->read_size_ = rc;
+		printf("read: %d\n", mg->read_size_);
+		
+		if (mg->read_size_ <= 0) {
+			strerror_r(errno, mg->errmsg_, MGCAP_ERR_LEN);
+			return -1;			
+		}
+		mg->cursol_ = &(mg->ibuf_[0]);
+		// printf("read size: %d (%d, %d)\n", mg->read_size_, mg->read_size_ / MGC_SNAPLEN,
+		// mg->read_size_ % MGC_SNAPLEN);
+	}
+	
+	memcpy(hdr, mg->cursol_, sizeof(mgcap_hdr));
+	mg->cursol_ += sizeof(mgcap_hdr);
+	*pktptr = mg->cursol_;
+	mg->cursol_ += MGC_SNAPLEN - sizeof(mgcap_hdr);
+ 
+	// mg->cursol_ += sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t) + hdr->pktlen_;
+	if (&(mg->ibuf_[0]) + mg->read_size_ <= mg->cursol_) {
+		mg->cursol_ = NULL;
+	}
+	
+	return 0;
+}
+
+

--- a/src/libmgcap/mgcap.c
+++ b/src/libmgcap/mgcap.c
@@ -78,19 +78,20 @@ int mgcap_next(mgcap_t* mg, void** pktptr, mgcap_hdr* hdr) {
 		}
 
 		mg->read_size_ = rc;
-		printf("read: %d\n", mg->read_size_);
 		
 		if (mg->read_size_ <= 0) {
 			strerror_r(errno, mg->errmsg_, MGCAP_ERR_LEN);
-			return -1;			
+			return -1;
 		}
 		mg->cursol_ = &(mg->ibuf_[0]);
 		// printf("read size: %d (%d, %d)\n", mg->read_size_, mg->read_size_ / MGC_SNAPLEN,
 		// mg->read_size_ % MGC_SNAPLEN);
 	}
-	
-	memcpy(hdr, mg->cursol_, sizeof(mgcap_hdr));
-	mg->cursol_ += sizeof(mgcap_hdr);
+
+	hdr->pktlen_ = *((uint16_t*)mg->cursol_);
+	mg->cursol_ += sizeof(hdr->pktlen_);
+	hdr->timestamp_ = *((uint64_t*)mg->cursol_);
+	mg->cursol_ += sizeof(hdr->timestamp_);
 	*pktptr = mg->cursol_;
 	mg->cursol_ += MGC_SNAPLEN - sizeof(mgcap_hdr);
  

--- a/src/libmgcap/mgcap.h
+++ b/src/libmgcap/mgcap.h
@@ -1,0 +1,19 @@
+#ifndef __LIBMGCAP_H__
+#define __LIBMGCAP_H__
+
+#include <stdint.h>
+
+typedef struct mgcap_ mgcap_t;
+
+typedef struct mgcap_hdr_ {
+	uint16_t pktlen_;
+	uint32_t ts_high_;
+	uint32_t ts_low_;
+} mgcap_hdr;
+
+mgcap_t* new_mgcap();
+void destroy_mgcap(mgcap_t* mg);
+int mgcap_set_device(mgcap_t* mg, const char* dev_name);
+int mgcap_next(mgcap_t* mg, void** pktptr, mgcap_hdr* hdr);
+
+#endif   // __LIBMGCAP_H__

--- a/src/libmgcap/mgcap.h
+++ b/src/libmgcap/mgcap.h
@@ -7,8 +7,7 @@ typedef struct mgcap_ mgcap_t;
 
 typedef struct mgcap_hdr_ {
 	uint16_t pktlen_;
-	uint32_t ts_high_;
-	uint32_t ts_low_;
+	uint32_t timestamp_;
 } mgcap_hdr;
 
 mgcap_t* new_mgcap();

--- a/src/libmgcap/mgcap.h
+++ b/src/libmgcap/mgcap.h
@@ -5,10 +5,12 @@
 
 typedef struct mgcap_ mgcap_t;
 
-typedef struct mgcap_hdr_ {
+struct mgcap_hdr_ {
 	uint16_t pktlen_;
-	uint32_t timestamp_;
-} mgcap_hdr;
+	uint64_t timestamp_;
+};
+
+typedef struct mgcap_hdr_ mgcap_hdr;
 
 mgcap_t* new_mgcap();
 void destroy_mgcap(mgcap_t* mg);

--- a/src/libmgcap/sample.c
+++ b/src/libmgcap/sample.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include "mgcap.h"
+
+int main(int argc, char* argv[]) {
+	mgcap_t *mg = new_mgcap();
+	int rc = mgcap_set_device(mg, "enp0s3");	
+	printf("mscap_set_device() = %d\n", rc);
+	
+	void *ptr;
+	mgcap_hdr hdr;
+	uint8_t *base, *p;
+	
+	while (0 <= (rc = mgcap_next(mg, &ptr, &hdr))) {
+		printf("pktlen=%u, ts=%lu:", hdr.pktlen_, hdr.timestamp_);
+		base = (uint8_t*)ptr;
+		for (p = base; p - base < 32; p++) {
+			printf(" %02X", *p);
+		}
+		printf("\n");
+	}
+
+	destroy_mgcap(mg);
+}


### PR DESCRIPTION
This patch introduces libmgcap that is pcap like library for mgcap. This has below functions.

- `mgcap_t* new_mgcap();`
- `void destroy_mgcap(mgcap_t* mg);`
- `int mgcap_set_device(mgcap_t* mg, const char* dev_name);`
- `int mgcap_next(mgcap_t* mg, void** pktptr, mgcap_hdr* hdr);`

Additionally, the patch has `sample.c` also. It shows example of libmgcap usage.